### PR TITLE
fix: struct field hover

### DIFF
--- a/syntaxes/go.tmLanguage.json
+++ b/syntaxes/go.tmLanguage.json
@@ -26,6 +26,9 @@
 				},
 				{
 					"include": "#group-variables"
+				},
+				{
+					"include": "#field_hover"
 				}
 			]
 		},
@@ -2895,6 +2898,38 @@
 						{
 							"match": "\\]",
 							"name": "punctuation.definition.end.bracket.square.go"
+						},
+						{
+							"match": "\\w+",
+							"name": "entity.name.type.go"
+						}
+					]
+				}
+			}
+		},
+		"field_hover": {
+			"comment": "struct field property and types when hovering with the mouse",
+			"match": "(?:(?<=^\\bfield\\b)\\s+([\\w\\*\\.]+)\\s+([\\s\\S]+))",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#type-declarations"
+						},
+						{
+							"match": "\\w+",
+							"name": "variable.other.property.go"
+						}
+					]
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#type-declarations"
+						},
+						{
+							"match": "\\binvalid\\b\\s+\\btype\\b",
+							"name": "invalid.field.go"
 						},
 						{
 							"match": "\\w+",

--- a/test/semantic_tokens.go
+++ b/test/semantic_tokens.go
@@ -4314,3 +4314,10 @@ type Bar287 = []struct {
 	bar    string
 	foobar *[]<-chan *[]context.Context
 }
+
+// v0.6.8
+func Bar288() {
+	// better highlighting struct properties and types when hovering with the mouse
+	type Foo struct{ name context.Context }
+	_ = Foo{name: context.TODO()}
+}

--- a/test/semantic_tokens.go.snap
+++ b/test/semantic_tokens.go.snap
@@ -41493,3 +41493,54 @@
 >}
 #^ source.go punctuation.definition.end.bracket.curly.go
 >
+>// v0.6.8
+#^^ source.go comment.line.double-slash.go punctuation.definition.comment.go
+#  ^^^^^^^ source.go comment.line.double-slash.go
+>func Bar288() {
+#^^^^ source.go keyword.function.go
+#    ^ source.go
+#     ^^^^^^ source.go entity.name.function.go
+#           ^ source.go punctuation.definition.begin.bracket.round.go
+#            ^ source.go punctuation.definition.end.bracket.round.go
+#             ^ source.go
+#              ^ source.go punctuation.definition.begin.bracket.curly.go
+>	// better highlighting struct properties and types when hovering with the mouse
+#^ source.go
+# ^^ source.go comment.line.double-slash.go punctuation.definition.comment.go
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.go comment.line.double-slash.go
+>	type Foo struct{ name context.Context }
+#^ source.go
+# ^^^^ source.go keyword.type.go
+#     ^ source.go
+#      ^^^ source.go entity.name.type.go
+#         ^ source.go
+#          ^^^^^^ source.go keyword.struct.go
+#                ^ source.go punctuation.definition.begin.bracket.curly.go
+#                 ^ source.go
+#                  ^^^^ source.go variable.other.property.go
+#                      ^ source.go
+#                       ^^^^^^^ source.go entity.name.type.go
+#                              ^ source.go punctuation.other.period.go
+#                               ^^^^^^^ source.go entity.name.type.go
+#                                      ^ source.go
+#                                       ^ source.go punctuation.definition.end.bracket.curly.go
+>	_ = Foo{name: context.TODO()}
+#^ source.go
+# ^ source.go variable.other.assignment.go
+#  ^ source.go
+#   ^ source.go keyword.operator.assignment.go
+#    ^ source.go
+#     ^^^ source.go entity.name.type.go
+#        ^ source.go punctuation.definition.begin.bracket.curly.go
+#         ^^^^ source.go variable.other.property.go
+#             ^ source.go punctuation.other.colon.go
+#              ^ source.go
+#               ^^^^^^^ source.go variable.other.go
+#                      ^ source.go punctuation.other.period.go
+#                       ^^^^ source.go entity.name.function.support.go
+#                           ^ source.go punctuation.definition.begin.bracket.round.go
+#                            ^ source.go punctuation.definition.end.bracket.round.go
+#                             ^ source.go punctuation.definition.end.bracket.curly.go
+>}
+#^ source.go punctuation.definition.end.bracket.curly.go
+>


### PR DESCRIPTION
Fixes struct field when hovering with the mouse.

**Before**
![before](https://github.com/worlpaker/go-syntax/assets/34960716/1d409661-72db-4dcc-b91f-ca0b53ce0b7a)

**After**
![after](https://github.com/worlpaker/go-syntax/assets/34960716/994332f1-3bba-46ca-9747-4c3b417ac94b)
